### PR TITLE
Changes to Complexes from Utah workshop

### DIFF
--- a/M2/Macaulay2/packages/Complexes.m2
+++ b/M2/Macaulay2/packages/Complexes.m2
@@ -114,11 +114,11 @@ homTensorAdjoint(Module, Module, Module) := (L, M, N) -> (
 --------------------------------------------------------------------
 -- package code ----------------------------------------------------
 --------------------------------------------------------------------
-load "Complexes/ChainComplex.m2"
-load "Complexes/FreeResolutions.m2"
-load "Complexes/ChainComplexMap.m2"
-load "Complexes/Tor.m2"
-load "Complexes/Ext.m2"
+load "./Complexes/ChainComplex.m2"
+load "./Complexes/FreeResolutions.m2"
+load "./Complexes/ChainComplexMap.m2"
+load "./Complexes/Tor.m2"
+load "./Complexes/Ext.m2"
 
 --------------------------------------------------------------------
 -- interface code to legacy types ----------------------------------
@@ -171,8 +171,8 @@ undocumented{
     component
     }
 
-load "Complexes/ChainComplexDoc.m2"
-load "Complexes/ChainComplexMapDoc.m2"
+load "./Complexes/ChainComplexDoc.m2"
+load "./Complexes/ChainComplexMapDoc.m2"
 
 --------------------------------------------------------------------
 -- documentation for legacy type conversion ------------------------
@@ -372,8 +372,8 @@ doc ///
 --------------------------------------------------------------------
 -- package tests ---------------------------------------------------
 --------------------------------------------------------------------
-load "Complexes/ChainComplexTests.m2"
-load "Complexes/FreeResolutionTests.m2"
+load "./Complexes/ChainComplexTests.m2"
+load "./Complexes/FreeResolutionTests.m2"
 
 end------------------------------------------------------------
 

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -1155,7 +1155,7 @@ yonedaExtension Matrix := Complex => f -> (
     g := homomorphism E.cache.yonedaExtension f; -- g: FM_d --> N
     -- if g has a non-zero degree, we must twist the target to preserve homogeneity
     gdegree := degree g;
-    g = map(N ** (ring g)^gdegree, source g, g);
+    g = map(N ** (ring g)^{gdegree}, source g, g);
     if d <= 0 then error "Yoneda extension only defined for Ext^d module for d at least 1";
     h := dd^FM_d || g;
     P := coker h; -- FM_d --> FM_(d-1) ++ N --> P --> 0

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -1131,6 +1131,7 @@ Ext(ZZ, Module, Module) := Module => opts -> (i,M,N) -> (
             );
         H.cache.yonedaExtension = liftmap;
         H.cache.yonedaExtension' = invmap;
+        H.cache.formation = FunctionApplication { Ext, (i, M, N) };
         H.cache.Ext = (i,M,N);
         H
         );

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -998,7 +998,7 @@ resolutionMapPrivate(Complex, Boolean) := ComplexMap => opts -> (C, isEpi) -> (
       or C.cache.resolutionMap.cache.LengthLimit < opts.LengthLimit then (
         (lo,hi) := concentration C;
         local f;
-        lengthlimit := defaultLengthLimit(ring C, length C, opts.LengthLimit);
+        lengthlimit := defaultLengthLimit(ring C, hi - lo, opts.LengthLimit);
         if lo === hi then (
             -- if C has only one nonzero module, use the faster free resolution code
             -- which is also important for Yoneda ext.
@@ -1029,11 +1029,11 @@ resolutionMapPrivate(Complex, Boolean) := ComplexMap => opts -> (C, isEpi) -> (
             -- of the base case above.
             f = naiveTruncation(f,(lo,infinity));
             );
-        f.cache.LengthLimit = if length source f < lengthlimit then infinity else lengthlimit;
+        f.cache.LengthLimit = if -difference concentration source f < lengthlimit then infinity else lengthlimit;
         C.cache.resolutionMap = f;
         );
     fC := C.cache.resolutionMap;
-    if opts.LengthLimit < length source fC
+    if opts.LengthLimit < -difference concentration source fC
     then naiveTruncation(fC, (0, opts.LengthLimit))
     else fC
     )

--- a/M2/Macaulay2/packages/Complexes/ChainComplexMap.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplexMap.m2
@@ -99,13 +99,9 @@ map(Complex, Complex, ZZ) := ComplexMap => opts -> (D, C, j) -> (
         result.cache.isCommutative = true;
         return result
         );
-    if j === 1 then (
-        if C == D and (opts.Degree === null or opts.Degree === 0) then
-            return id_C;
-        error "expected source and target to be the same";
-        );
-    error "expected integer to be zero or one";
-    )
+    if C == D and (opts.Degree === null or opts.Degree === 0) then
+        return j * id_C;
+    error "expected 0 or source and target to be the same")
 
 map(Complex, Complex, ComplexMap) := ComplexMap => opts -> (tar, src, f) -> (
     deg := if opts.Degree === null then degree f else opts.Degree;

--- a/M2/Macaulay2/packages/Complexes/ChainComplexTests.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplexTests.m2
@@ -2009,10 +2009,12 @@ TEST ///
   restart
   needsPackage "Complexes"
 *-
-
   S = ZZ/101[a..d, Degrees=>{2:{1,0},2:{0,1}}]
   B = ideal(a,b) * ideal(c,d)
-  Ext^1(B, S)
+  E = Ext^1(B, S)
+  C = yonedaExtension map(E, , matrix random cover E)
+  assert(C_0 == module B)
+  assert(C_2 == module S)
   F = random({1,2}, S)
   f = map(S^1, S^{-degree F}, {{F}})
   assert isHomogeneous f


### PR DESCRIPTION
This is a rebase of https://github.com/Macaulay2/M2/pull/3342 on top of your working branch.

These are changes to the Complexes package that I extracted from the Varieties branch from the recent workshop. Since Mike mentioned changes to the Complexes are happening now, I extracted these commits now, hoping to prevent a big merge conflict in the future.

- **fixed load paths in Complexes**
- **removed calls to length Complex in resolutionMap**
- **added formation for Ext modules in Complexes**
- **fixed map(Complex, Complex, ZZ) to allow multiplication maps**

cc: @mikestillman @ggsmith 