### PR TITLE
More standalone engine stuff

### DIFF
--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -4,6 +4,7 @@
 #include <M2/gc-include.h>
 
 #include "interp-exports.h"
+#include <interface/m2-types.h>
 
 #include "M2mem.h"
 #include "types.h"
@@ -93,6 +94,10 @@ int main(/* const */ int argc, /* const */ char *argv[], /* const */ char *env[]
   signal(SIGPIPE,SIG_IGN); /* ignore the broken pipe signal */
 
   flint_set_abort(M2_flint_abort);
+
+  tonetCCparenpointer = gmp_tonetCCparenpointer;
+  tonetCCpointer = gmp_tonetCCpointer;
+  tostringRRpointer = gmp_tostringRRpointer;
 
   static struct ArgCell* M2_vargs;
   M2_vargs = (ArgCell*) GC_MALLOC_UNCOLLECTABLE(sizeof(struct ArgCell));

--- a/M2/Macaulay2/c/scc1.c
+++ b/M2/Macaulay2/c/scc1.c
@@ -333,8 +333,6 @@ int main(int argc, char **argv){
 		    if (NULL == freopen(n,"w", stdout)) {
 			 fatal("can't open file %s",n);
 			 }
-		    put("#ifndef D_GENERATED_H\n");
-		    put("#define D_GENERATED_H\n");
 		    printf("#ifndef %s_included\n",targetname);
 		    printf("#define %s_included\n",targetname);
 		    declarationsstrings = reverse(declarationsstrings);
@@ -349,7 +347,6 @@ int main(int argc, char **argv){
 		    /* printtypecodes(); */
 		    cprinttypes();
 		    put(declarations_trailer);
-		    put("#endif\n");
 		    put("#endif\n");
 		    }
 	       if (TRUE) {

--- a/M2/Macaulay2/e/aring-CC.cpp
+++ b/M2/Macaulay2/e/aring-CC.cpp
@@ -11,7 +11,7 @@ void ARingCC::elem_text_out(buffer &o,
 {
   gmp_CC g = toBigComplex(ap);
   M2_string s =
-    p_parens ? (*gmp_tonetCCparenpointer)(g) : (*gmp_tonetCCpointer)(g);
+    p_parens ? (*tonetCCparenpointer)(g) : (*tonetCCpointer)(g);
   
   bool prepend_plus = p_plus && (s->array[0] != '-');
   bool strip_last =

--- a/M2/Macaulay2/e/aring-CCC.cpp
+++ b/M2/Macaulay2/e/aring-CCC.cpp
@@ -14,7 +14,7 @@ void ARingCCC::elem_text_out(buffer &o,
   g.re = &const_cast<ElementType &>(f).re;
   g.im = &const_cast<ElementType &>(f).im;
   M2_string s =
-      p_parens ? (*gmp_tonetCCparenpointer)(&g) : (*gmp_tonetCCpointer)(&g);
+      p_parens ? (*tonetCCparenpointer)(&g) : (*tonetCCpointer)(&g);
 
   // if: first char is a "-", and p_plus, o << "+"
   // if: an internal "+" or "-", then put parens around it.

--- a/M2/Macaulay2/e/aring-RR.cpp
+++ b/M2/Macaulay2/e/aring-RR.cpp
@@ -13,7 +13,7 @@ void ARingRR::elem_text_out(buffer &o,
   mpfr_t a;
   mpfr_init(a);
   mpfr_set_d(a, ap1, MPFR_RNDN);
-  M2_string s = (*gmp_tostringRRpointer)(a);
+  M2_string s = (*tostringRRpointer)(a);
   mpfr_clear(a);
   bool prepend_plus = p_plus && (s->array[0] != '-');
   bool strip_last =

--- a/M2/Macaulay2/e/aring-RRR.cpp
+++ b/M2/Macaulay2/e/aring-RRR.cpp
@@ -10,7 +10,7 @@ void ARingRRR::elem_text_out(buffer &o,
                              bool p_parens) const
 {
   mpfr_ptr a = &const_cast<ElementType &>(ap);
-  M2_string s = (*gmp_tostringRRpointer)(a);
+  M2_string s = (*tostringRRpointer)(a);
   bool prepend_plus = p_plus && (s->array[0] != '-');
   bool strip_last =
       !p_one && ((s->len == 1 && s->array[0] == '1') ||

--- a/M2/Macaulay2/e/aring-RRi.cpp
+++ b/M2/Macaulay2/e/aring-RRi.cpp
@@ -10,8 +10,8 @@ void ARingRRi::elem_text_out(buffer &o,
                              bool p_parens) const
 {
   mpfi_ptr a = &const_cast<ElementType &>(ap);
-  M2_string s1 = (*gmp_tostringRRpointer)(&(a->left));
-  M2_string s2 = (*gmp_tostringRRpointer)(&(a->right));
+  M2_string s1 = (*tostringRRpointer)(&(a->left));
+  M2_string s2 = (*tostringRRpointer)(&(a->right));
 
   if(p_plus) o << "+";
   o << "[";

--- a/M2/Macaulay2/e/debug.cpp
+++ b/M2/Macaulay2/e/debug.cpp
@@ -145,7 +145,7 @@ void dstash()
 void dRRR(gmp_RR a)
 {
   buffer o;
-  o << M2_tocharstar((*gmp_tostringRRpointer)(a)) << newline;
+  o << M2_tocharstar((*tostringRRpointer)(a)) << newline;
   emit(o.str());
 }
 

--- a/M2/Macaulay2/e/interface/m2-types.cpp
+++ b/M2/Macaulay2/e/interface/m2-types.cpp
@@ -46,9 +46,9 @@ M2_string M2_tostringn(char *s, int n)
     return p;
 }
 
-M2_string (*gmp_tonetCCparenpointer)(gmp_CC);
-M2_string (*gmp_tonetCCpointer)(gmp_CC);
-M2_string (*gmp_tostringRRpointer)(mpfr_srcptr);
+M2_string (*tonetCCparenpointer)(gmp_CC);
+M2_string (*tonetCCpointer)(gmp_CC);
+M2_string (*tostringRRpointer)(mpfr_srcptr);
 
 
 char newline[] = "\n";

--- a/M2/Macaulay2/e/interface/m2-types.h
+++ b/M2/Macaulay2/e/interface/m2-types.h
@@ -152,11 +152,6 @@ typedef const struct Matrix * engine_RawMatrixOrNull;
 extern "C" {
 #endif
 
-  extern M2_string (*tonetCCparenpointer)(gmp_CC);
-  extern M2_string (*tonetCCpointer)(gmp_CC);
-  extern M2_string (*tostringRRipointer)(mpfi_srcptr);
-  extern M2_string (*tostringRRpointer)(mpfr_srcptr);
-  
   M2_arrayint M2_makearrayint(int n);
   char * M2_tocharstar(M2_string s);
   M2_string M2_join(M2_string x, M2_string y);
@@ -172,4 +167,8 @@ extern int M2_numTBBThreads;
 extern int M2_gbTrace;
 extern int M2_numericalAlgebraicGeometryTrace;
 
-#endif
+#endif // !defined(SAFEC_EXPORTS)
+
+extern M2_string (*tonetCCparenpointer)(gmp_CC);
+extern M2_string (*tonetCCpointer)(gmp_CC);
+extern M2_string (*tostringRRpointer)(mpfr_srcptr);

--- a/M2/Macaulay2/e/interface/m2-types.h
+++ b/M2/Macaulay2/e/interface/m2-types.h
@@ -31,7 +31,6 @@
 #if !defined(SAFEC_EXPORTS)
 typedef char M2_bool;
 
-#ifndef D_GENERATED_H
 typedef struct M2_string_struct * M2_string;
 struct M2_string_struct {int len;signed char array[];};
 
@@ -42,7 +41,6 @@ struct M2_arrayint_struct {int len;int array[];};
 typedef struct M2_ArrayString_struct * M2_ArrayString;
 typedef M2_ArrayString M2_ArrayStringOrNull;
 struct M2_ArrayString_struct {int len;M2_string array[];};
-#endif
 
 struct MonomialOrdering;
 struct Ring;

--- a/M2/Macaulay2/e/interface/m2-types.h
+++ b/M2/Macaulay2/e/interface/m2-types.h
@@ -152,20 +152,16 @@ typedef const struct Matrix * engine_RawMatrixOrNull;
 extern "C" {
 #endif
 
-  extern M2_string (*gmp_tonetCCparenpointer)(gmp_CC);
-  extern M2_string (*gmp_tonetCCpointer)(gmp_CC);
-  extern M2_string (*gmp_tostringRRipointer)(mpfi_srcptr);
-  extern M2_string (*gmp_tostringRRpointer)(mpfr_srcptr);
+  extern M2_string (*tonetCCparenpointer)(gmp_CC);
+  extern M2_string (*tonetCCpointer)(gmp_CC);
+  extern M2_string (*tostringRRipointer)(mpfi_srcptr);
+  extern M2_string (*tostringRRpointer)(mpfr_srcptr);
   
   M2_arrayint M2_makearrayint(int n);
   char * M2_tocharstar(M2_string s);
   M2_string M2_join(M2_string x, M2_string y);
   M2_string M2_tostring(const char* s);
   M2_string M2_tostringn(char *s, int n);
-
-  //  M2_string (*gmp_tonetCCparenpointer)(gmp_CC);
-  //  M2_string (*gmp_tonetCCpointer)(gmp_CC);
-  //  M2_string (*gmp_tostringRRpointer)(mpfr_srcptr);
 
 #if defined(__cplusplus)
 }

--- a/M2/Macaulay2/e/unit-tests/M2-replacement.c
+++ b/M2/Macaulay2/e/unit-tests/M2-replacement.c
@@ -48,9 +48,9 @@ M2_string M2_tostringn(char *s, int n)
     return p;
 }
 
-M2_string (*gmp_tonetCCparenpointer)(gmp_CC);
-M2_string (*gmp_tonetCCpointer)(gmp_CC);
-M2_string (*gmp_tostringRRpointer)(mpfr_srcptr);
+M2_string (*tonetCCparenpointer)(gmp_CC);
+M2_string (*tonetCCpointer)(gmp_CC);
+M2_string (*tostringRRpointer)(mpfr_srcptr);
 
 
 char newline[] = "\n";


### PR DESCRIPTION
This finishes fixing the multiple definition errors, and also removes the D_GENERATED_H header guard I had added.  I'm not sure why I thought it was needed...

TODO: get the various tostring functions from gmp.d to actually work so we don't segfault