### PR TITLE
Build engine as a standalone library (static or shared)

### DIFF
--- a/M2/Macaulay2/bin/Makefile.in
+++ b/M2/Macaulay2/bin/Makefile.in
@@ -22,7 +22,7 @@ endif
 NORULES = yes
 include ../../include/config.Makefile
 include ../d/Makefile.files
-include @srcdir@/../e/Makefile.files
+include ../e/Makefile.files
 include @srcdir@/../system/Makefile.files
 
 %.o : %.c
@@ -33,7 +33,7 @@ include @srcdir@/../system/Makefile.files
 %.o : %.s
 
 # warning: static initializers are run in left-to-right order, and some of them depend on others of them
-M2_OBJECTS := $(SYSTEM_OFILES:%=../system/%) $(ENGINE_OFILES:%=../e/%) $(M2_OBJECTS:%=../d/%) $(patsubst %, ../d/%.o, $(M2_DNAMES))
+M2_OBJECTS := $(SYSTEM_OFILES:%=../system/%) $(M2_OBJECTS:%=../d/%) $(patsubst %, ../d/%.o, $(M2_DNAMES)) $(LIBENGINE)
 
 EXEFILE = @pre_bindir@/M2@EXE@
 M2SCRIPT = @pre_bindir@/M2

--- a/M2/Macaulay2/e/Makefile.common.in
+++ b/M2/Macaulay2/e/Makefile.common.in
@@ -73,6 +73,12 @@ COMPILE.cpp = $(COMPILE.cc)
 	$(SHOW)"MKDEP $*.c"
 	$(HIDE)@CC@  -MT $@ -MT $*.o -MM -MP $(CFLAGS)   $(CPPFLAGS) $(TARGET_ARCH) $(MORE_OPTIONS) $< >$*.dep
 
+@pre_librariesdir@/libengine.so: $(LOFILES)
+	@CC@ -shared $^ $(OUTPUT_OPTION)
+
+@pre_librariesdir@/libengine.a: $(ENGINE_OFILES)
+	@AR@ rcs $@ $^
+
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/e DEPENDS=no initialize && make -C $M2BUILDDIR/Macaulay2/e Makefile.common "
 # End:

--- a/M2/Macaulay2/e/Makefile.files.in
+++ b/M2/Macaulay2/e/Makefile.files.in
@@ -243,8 +243,10 @@ ENGINE_OFILES := $(addsuffix .o,$(C_FILES) $(CC_FILES) $(D_FILES) $(DD_FILES))
 
 ifeq "$(SHARED)" "yes"
 ENGINE_OBJFILES := $(LOFILES)
+LIBENGINE = @pre_librariesdir@/libengine.so
 else
 ENGINE_OBJFILES := $(ENGINE_OFILES)
+LIBENGINE = @pre_librariesdir@/libengine.a
 endif
 
 HHFILES := $(addsuffix .hpp, $(NAMES_H) $(NAMES) $(INTERFACE) $(INTERFACE2)) $(E_H)

--- a/M2/Macaulay2/e/Makefile.in
+++ b/M2/Macaulay2/e/Makefile.in
@@ -57,11 +57,7 @@ clean :: ; rm -f overflow-test
 
 #all:; $(MAKE) -C f4
 
-ifeq "$(SHARED)" "yes"
-all: @pre_librariesdir@/libengine.so
-else
-all: $(ENGINE_OFILES)
-endif
+all: $(LIBENGINE)
 
 %.ii: %.cpp; $(PRE.cc)        $< $(OUTPUT_OPTION)
 %.s : %.cpp; $(COMPILE.cc) -S $< $(OUTPUT_OPTION)
@@ -72,7 +68,6 @@ endif
 %.lo : %.c  ; $(COMPILE.c)  -fPIC $< $(OUTPUT_OPTION)
 %.lo : %.cc ; $(COMPILE.cc) -fPIC $< $(OUTPUT_OPTION)
 %.lo : %.cpp; $(COMPILE.cc) -fPIC $< $(OUTPUT_OPTION)
-@pre_librariesdir@/libengine.so : $(LOFILES); @CC@ -shared $^ $(OUTPUT_OPTION)
 
 MORE_OPTIONS = -Wno-cast-qual
 COMPILE.c += $(MORE_OPTIONS)
@@ -89,7 +84,7 @@ clean::
 Makefile : Makefile.in; cd ../..; ./config.status Macaulay2/e/Makefile
 all: Makefile.common
 Makefile.common : Makefile.common.in; cd ../..; ./config.status Macaulay2/e/Makefile.common
-Makefile.include : Makefile.include.in; cd ../..; ./config.status Macaulay2/e/Makefile.include
+Makefile.files : Makefile.files.in; cd ../..; ./config.status Macaulay2/e/Makefile.files
 clean::; rm -f *.dep dep-*.tmp typecode.db TAGS
 ifeq "$(DEPENDS)" "yes"
 include $(ENGINE_CFILES:.c=.dep) $(ENGINE_CCFILES:.cpp=.dep)

--- a/M2/Macaulay2/e/unit-tests/Makefile.in
+++ b/M2/Macaulay2/e/unit-tests/Makefile.in
@@ -18,7 +18,7 @@ LOADLIBES += @BUILTLIBS@ @LINALGLIBS@ @LIBS@ @FCLIBS@ -lgtest -pthread
 
 .PHONY: place_into_lib runtests
 
-all: $(UNITTEST_OBJECT_FILES) $(E_OBJECT_FILES)
+all: $(UNITTEST_OBJECT_FILES) $(LIBENGINE)
 	echo @BUILTLIBS@
 	echo @LIBS@
 
@@ -30,22 +30,22 @@ check: runtests
 fullCheck: $(UNITTEST_TARGET)
 	valgrind --track-origins=yes ./$(UNITTEST_TARGET)
 
-$(UNITTEST_TARGET) : $(UNITTEST_OBJECT_FILES) $(E_OBJECT_FILES) # ../../system/supervisor.o
+$(UNITTEST_TARGET) : $(UNITTEST_OBJECT_FILES) $(LIBENGINE) # ../../system/supervisor.o
 	@CXX@ $(LDFLAGS) $^ $(LOADLIBES) -o $@
 
 runtests: $(UNITTEST_TARGET)
 	time ./$(UNITTEST_TARGET)
 
-ARingRRRTest :  ARingRRRTest.o $(UNITTEST_SHARED_OBJECT_FILES) $(E_OBJECT_FILES)
+ARingRRRTest :  ARingRRRTest.o $(UNITTEST_SHARED_OBJECT_FILES) $(LIBENGINE)
 	@CXX@ $(LDFLAGS) $^ $(LOADLIBES) -o $@
 
-ARingRRiTest :  ARingRRiTest.o $(UNITTEST_SHARED_OBJECT_FILES) $(E_OBJECT_FILES)
+ARingRRiTest :  ARingRRiTest.o $(UNITTEST_SHARED_OBJECT_FILES) $(LIBENGINE)
 	@CXX@ $(LDFLAGS) $^ $(LOADLIBES) -o $@
 
-ARingGFTest :  ARingGFTest.o $(UNITTEST_SHARED_OBJECT_FILES) $(E_OBJECT_FILES) # ../../system/supervisor.o
+ARingGFTest :  ARingGFTest.o $(UNITTEST_SHARED_OBJECT_FILES) $(LIBENGINE) # ../../system/supervisor.o
 	@CXX@ $(LDFLAGS) $^ $(LOADLIBES) -o $@
 
-NCGroebnerTest :  NCGroebnerTest.o $(UNITTEST_SHARED_OBJECT_FILES) $(E_OBJECT_FILES) # ../../system/supervisor.o
+NCGroebnerTest :  NCGroebnerTest.o $(UNITTEST_SHARED_OBJECT_FILES) $(LIBENGINE) # ../../system/supervisor.o
 	@CXX@ $(LDFLAGS) $^ $(LOADLIBES) -o $@
 
 runNCGroebnerTest : NCGroebnerTest
@@ -60,7 +60,7 @@ ARingRRRZZpTest : \
     RingQQTest.o \
     RingRRRTest.o \
     RingCCCTest.o \
-    $(UNITTEST_SHARED_OBJECT_FILES) $(E_OBJECT_FILES)
+    $(UNITTEST_SHARED_OBJECT_FILES) $(LIBENGINE)
 	@CXX@ $(LDFLAGS) $^ $(LOADLIBES) -o $@
 
 checkGivaro: GivaroTest

--- a/M2/m4/files
+++ b/M2/m4/files
@@ -73,6 +73,7 @@ Macaulay2/bin/Makefile
 Macaulay2/bin/M2
 Macaulay2/e/Makefile
 Macaulay2/e/Makefile.common
+Macaulay2/e/Makefile.files
 Macaulay2/e/unit-tests/Makefile
 Macaulay2/editors/Makefile
 Macaulay2/html-check-links/Makefile


### PR DESCRIPTION
Rather than linking with all the various .o files from the e directory, we instead build a static (or shared if `SHARED` is "yes") library (libengine) and link with that, both for the M2 binary and the unit tests